### PR TITLE
Add npm script to list missing manifests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warframe-steam-manifests",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "wanted": "node scripts/wanted.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "wanted": "node scripts/wanted.js",
-    "test": "echo \"No tests specified\" && exit 0"
+    "wanted": "node scripts/wanted.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "warframe-steam-manifests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "wanted": "node scripts/wanted.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  }
+}

--- a/scripts/wanted.js
+++ b/scripts/wanted.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const manifestsFile = path.join(__dirname, '..', 'manifests.txt');
+const manifestsDir = path.join(__dirname, '..', 'manifests');
+
+// Read manifest IDs from manifests.txt (second column of each line)
+const desiredIds = fs.readFileSync(manifestsFile, 'utf8')
+  .split(/\r?\n/)
+  .filter(Boolean)
+  .map(line => line.trim().split(/\s+/).pop());
+
+// Collect existing IDs from manifest filenames
+const existingIds = new Set(
+  fs.readdirSync(manifestsDir)
+    .map(name => name.match(/_(\d+)\.txt$/))
+    .filter(Boolean)
+    .map(match => match[1])
+);
+
+// Determine missing IDs
+const missing = desiredIds.filter(id => !existingIds.has(id));
+
+// Output missing IDs, one per line
+console.log(missing.join('\n'));

--- a/scripts/wanted.js
+++ b/scripts/wanted.js
@@ -1,25 +1,27 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-const manifestsFile = path.join(__dirname, '..', 'manifests.txt');
-const manifestsDir = path.join(__dirname, '..', 'manifests');
+const manifestsFile = path.join(__dirname, "..", "manifests.txt");
+const manifestsDir = path.join(__dirname, "..", "manifests");
 
 // Read manifest IDs from manifests.txt (second column of each line)
-const desiredIds = fs.readFileSync(manifestsFile, 'utf8')
+const desiredIds = fs
+  .readFileSync(manifestsFile, "utf8")
   .split(/\r?\n/)
   .filter(Boolean)
-  .map(line => line.trim().split(/\s+/).pop());
+  .map((line) => line.trim().split(/\s+/).pop());
 
 // Collect existing IDs from manifest filenames
 const existingIds = new Set(
-  fs.readdirSync(manifestsDir)
-    .map(name => name.match(/_(\d+)\.txt$/))
+  fs
+    .readdirSync(manifestsDir)
+    .map((name) => name.match(/_(\d+)\.txt$/))
     .filter(Boolean)
-    .map(match => match[1])
+    .map((match) => match[1]),
 );
 
 // Determine missing IDs
-const missing = desiredIds.filter(id => !existingIds.has(id));
+const missing = desiredIds.filter((id) => !existingIds.has(id));
 
 // Output missing IDs, one per line
-console.log(missing.join('\n'));
+console.log(missing.join("\n"));


### PR DESCRIPTION
## Summary
- add `npm run wanted` to list manifest IDs missing from the manifests folder
- include placeholder `npm test` script

## Testing
- `npm test`
- `npm run wanted`


------
https://chatgpt.com/codex/tasks/task_e_68acff4ad5648325a943faf687d415b3