### PR TITLE
Add manifest verification script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "prettier": "prettier --write .",
     "wanted": "node scripts/wanted.js",
     "size": "node scripts/size.js",
-    "update": "node scripts/size.js > size.txt"
+    "update": "node scripts/size.js > size.txt",
+    "verify": "node scripts/verify.js"
   },
   "devDependencies": {
     "prettier": "^3.6.2"

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,0 +1,111 @@
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+function findManifest(id) {
+  const manifestsDir = path.join(__dirname, "..", "manifests");
+  const name = fs
+    .readdirSync(manifestsDir)
+    .find((file) => file.endsWith(`_${id}.txt`));
+  if (!name) return null;
+  return path.join(manifestsDir, name);
+}
+
+function parseManifest(file) {
+  const map = new Map();
+  const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const match = line.match(/^\s*(\d+)\s+\d+\s+([0-9a-f]{40})\s+\d+\s+(.+)$/i);
+    if (!match) continue;
+    const size = Number(match[1]);
+    const sha = match[2].toLowerCase();
+    const name = match[3].trim();
+    if (/^0{40}$/.test(sha)) continue; // directory entry
+    map.set(name.replace(/\\/g, "/"), { size, sha });
+  }
+  return map;
+}
+
+function listFiles(dir) {
+  const result = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...listFiles(full));
+    } else if (entry.isFile()) {
+      result.push(full);
+    }
+  }
+  return result;
+}
+
+function sha1(file) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash("sha1");
+    const stream = fs.createReadStream(file);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+async function main() {
+  const [manifestId, targetPath] = process.argv.slice(2);
+  if (!manifestId || !targetPath) {
+    console.error("Usage: node scripts/verify.js <manifestId> <path>");
+    process.exit(1);
+  }
+
+  const manifestFile = findManifest(manifestId);
+  if (!manifestFile) {
+    console.error(`Manifest ${manifestId} not found`);
+    process.exit(1);
+  }
+
+  const manifest = parseManifest(manifestFile);
+  const missing = [];
+  const mismatched = [];
+
+  for (const [rel, { size, sha }] of manifest.entries()) {
+    const abs = path.join(targetPath, rel.split("/").join(path.sep));
+    if (!fs.existsSync(abs)) {
+      missing.push(rel);
+      continue;
+    }
+    const stats = fs.statSync(abs);
+    if (stats.size !== size) {
+      mismatched.push(`${rel} (size ${stats.size} != ${size})`);
+      continue;
+    }
+    const actualSha = await sha1(abs);
+    if (actualSha !== sha) {
+      mismatched.push(`${rel} (sha ${actualSha} != ${sha})`);
+    }
+  }
+
+  const allFiles = listFiles(targetPath).map((f) =>
+    path.relative(targetPath, f).split(path.sep).join("/"),
+  );
+  const superfluous = allFiles.filter((f) => !manifest.has(f));
+
+  if (missing.length) {
+    console.log("Missing files:");
+    for (const file of missing) console.log("  " + file);
+  }
+  if (mismatched.length) {
+    console.log("Mismatched files:");
+    for (const file of mismatched) console.log("  " + file);
+  }
+  if (superfluous.length) {
+    console.log("Superfluous files:");
+    for (const file of superfluous) console.log("  " + file);
+  }
+  console.log(
+    `Checked ${manifest.size} files; ${missing.length} missing, ${mismatched.length} mismatched, ${superfluous.length} superfluous.`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to verify directory against a manifest by id
- expose verifier with `npm run verify`

## Testing
- `npx prettier scripts/verify.js package.json --write`
- `node scripts/verify.js 1040973097284770411 scripts`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ad21616e588325a68967d8f5f273c7