### PR TITLE
Add script to capture delta metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "prettier": "prettier --write .",
     "update": "node scripts/update.js",
-    "verify": "node scripts/verify.js"
+    "verify": "node scripts/verify.js",
+    "delta": "node scripts/add-delta.js"
   },
   "devDependencies": {
     "prettier": "^3.6.2"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "prettier": "prettier --write .",
     "update": "node scripts/update.js",
     "verify": "node scripts/verify.js",
-    "delta": "node scripts/add-delta.js"
+    "add-delta": "node scripts/add-delta.js"
   },
   "devDependencies": {
     "prettier": "^3.6.2"

--- a/scripts/add-delta.js
+++ b/scripts/add-delta.js
@@ -1,17 +1,7 @@
 const fs = require("fs");
 const path = require("path");
-const crypto = require("crypto");
 const { execFileSync } = require("child_process");
-
-function sha1(file) {
-  return new Promise((resolve, reject) => {
-    const hash = crypto.createHash("sha1");
-    const stream = fs.createReadStream(file);
-    stream.on("error", reject);
-    stream.on("data", (chunk) => hash.update(chunk));
-    stream.on("end", () => resolve(hash.digest("hex")));
-  });
-}
+const sha1 = require("./sha1");
 
 async function main() {
   const [deltaPath] = process.argv.slice(2);

--- a/scripts/add-delta.js
+++ b/scripts/add-delta.js
@@ -1,0 +1,55 @@
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const { execFileSync } = require("child_process");
+
+function sha1(file) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash("sha1");
+    const stream = fs.createReadStream(file);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+async function main() {
+  const [deltaPath] = process.argv.slice(2);
+  if (!deltaPath) {
+    console.error("Usage: node scripts/add-delta.js <deltaFile>");
+    process.exit(1);
+  }
+
+  const full = path.resolve(deltaPath);
+  if (!fs.existsSync(full)) {
+    console.error(`File not found: ${full}`);
+    process.exit(1);
+  }
+
+  const out = path.join(
+    __dirname,
+    "..",
+    "deltas",
+    path.basename(full) + ".txt",
+  );
+
+  const size = fs.statSync(full).size;
+  const hash = await sha1(full);
+
+  let cid;
+  try {
+    cid = execFileSync("ipfs", ["add", "-Q", full], {
+      encoding: "utf8",
+    }).trim();
+  } catch (err) {
+    console.error("Failed to run ipfs add: " + err.message);
+    process.exit(1);
+  }
+
+  fs.writeFileSync(out, `${size}\n${hash}\n${cid}\n`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/add-delta.js
+++ b/scripts/add-delta.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const { execFileSync } = require("child_process");
-const sha1 = require("./sha1");
+const { sha1 } = require("./common");
 
 async function main() {
   const [deltaPath] = process.argv.slice(2);

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const crypto = require("crypto");
 
-module.exports = function sha1(file) {
+function sha1(file) {
   return new Promise((resolve, reject) => {
     const hash = crypto.createHash("sha1");
     const stream = fs.createReadStream(file);
@@ -9,4 +9,8 @@ module.exports = function sha1(file) {
     stream.on("data", (chunk) => hash.update(chunk));
     stream.on("end", () => resolve(hash.digest("hex")));
   });
+}
+
+module.exports = {
+  sha1,
 };

--- a/scripts/sha1.js
+++ b/scripts/sha1.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const crypto = require("crypto");
+
+module.exports = function sha1(file) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash("sha1");
+    const stream = fs.createReadStream(file);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+};

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const sha1 = require("./sha1");
+const { sha1 } = require("./common");
 
 function findManifest(id) {
   const manifestsDir = path.join(__dirname, "..", "manifests");

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const crypto = require("crypto");
+const sha1 = require("./sha1");
 
 function findManifest(id) {
   const manifestsDir = path.join(__dirname, "..", "manifests");
@@ -39,16 +39,6 @@ function listFiles(dir) {
     }
   }
   return result;
-}
-
-function sha1(file) {
-  return new Promise((resolve, reject) => {
-    const hash = crypto.createHash("sha1");
-    const stream = fs.createReadStream(file);
-    stream.on("error", reject);
-    stream.on("data", (chunk) => hash.update(chunk));
-    stream.on("end", () => resolve(hash.digest("hex")));
-  });
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- add `scripts/add-delta.js` to compute size, SHA1, and IPFS CID for a delta file and record it in the `deltas` folder
- expose helper via npm script `delta`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68afe6b6b8808325a14c9ba49a2bae98