### PR TITLE
Align size units to right in README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <tr>
       <td><code>2025-06-25T15:03:33Z</code></td>
       <td>8391191747297658560</td>
-      <td><a href="manifests/manifest_230411_8391191747297658560.txt">46.38 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8391191747297658560.txt">46.38 GiB</a></td>
       <td><a href="ipfs/8391191747297658560.txt">IPFS CIDs</a></td>
       <td></td>
       <td></td>
@@ -21,7 +21,7 @@
     <tr>
       <td><code>2025-05-21T15:02:16Z</code></td>
       <td>6046892458385712496</td>
-      <td><a href="manifests/manifest_230411_6046892458385712496.txt">45.95 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6046892458385712496.txt">45.95 GiB</a></td>
       <td><a href="ipfs/6046892458385712496.txt">IPFS CIDs</a></td>
       <td></td>
       <td></td>
@@ -29,7 +29,7 @@
     <tr>
       <td><code>2025-03-19T14:55:56Z</code></td>
       <td>4212893560910494140</td>
-      <td><a href="manifests/manifest_230411_4212893560910494140.txt">45.79 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4212893560910494140.txt">45.79 GiB</a></td>
       <td><a href="ipfs/4212893560910494140.txt">IPFS CIDs</a></td>
       <td></td>
       <td></td>
@@ -37,7 +37,7 @@
     <tr>
       <td><code>2024-12-13T14:01:34Z</code></td>
       <td>3864063200081954630</td>
-      <td><a href="manifests/manifest_230411_3864063200081954630.txt">44.89 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3864063200081954630.txt">44.89 GiB</a></td>
       <td><a href="ipfs/3864063200081954630.txt">IPFS CIDs</a></td>
       <td></td>
       <td></td>
@@ -45,7 +45,7 @@
     <tr>
       <td><code>2024-10-11T16:05:33Z</code></td>
       <td>513490184226321110</td>
-      <td><a href="manifests/manifest_230411_513490184226321110.txt">42.80 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_513490184226321110.txt">42.80 GiB</a></td>
       <td><a href="ipfs/513490184226321110.txt">IPFS CIDs</a></td>
       <td></td>
       <td></td>
@@ -53,7 +53,7 @@
     <tr>
       <td><code>2024-10-02T15:01:14Z</code></td>
       <td>2655930801276651913</td>
-      <td><a href="manifests/manifest_230411_2655930801276651913.txt">42.80 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2655930801276651913.txt">42.80 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -61,7 +61,7 @@
     <tr>
       <td><code>2024-08-22T15:13:48Z</code></td>
       <td>8111233839173446959</td>
-      <td><a href="manifests/manifest_230411_8111233839173446959.txt">41.24 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8111233839173446959.txt">41.24 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -69,7 +69,7 @@
     <tr>
       <td><code>2024-07-20T14:00:43Z</code></td>
       <td>7104716125379362906</td>
-      <td><a href="manifests/manifest_230411_7104716125379362906.txt">41.18 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7104716125379362906.txt">41.18 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -77,7 +77,7 @@
     <tr>
       <td><code>2024-06-26T14:41:47Z</code></td>
       <td>8456987056335242580</td>
-      <td><a href="manifests/manifest_230411_8456987056335242580.txt">40.62 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8456987056335242580.txt">40.62 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -85,7 +85,7 @@
     <tr>
       <td><code>2024-06-18T15:01:05Z</code></td>
       <td>8444137865636064549</td>
-      <td><a href="manifests/manifest_230411_8444137865636064549.txt">40.63 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8444137865636064549.txt">40.63 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -93,7 +93,7 @@
     <tr>
       <td><code>2024-03-27T15:00:27Z</code></td>
       <td>4262681179882731333</td>
-      <td><a href="manifests/manifest_230411_4262681179882731333.txt">40.19 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4262681179882731333.txt">40.19 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -101,7 +101,7 @@
     <tr>
       <td><code>2024-02-20T22:47:18Z</code></td>
       <td>3417254152679980994</td>
-      <td><a href="manifests/manifest_230411_3417254152679980994.txt">39.69 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3417254152679980994.txt">39.69 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -109,7 +109,7 @@
     <tr>
       <td><code>2023-07-27T15:56:41Z</code></td>
       <td>4487452668036984689</td>
-      <td><a href="manifests/manifest_230411_4487452668036984689.txt">36.34 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4487452668036984689.txt">36.34 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -117,7 +117,7 @@
     <tr>
       <td><code>2023-06-22T21:18:24Z</code></td>
       <td>7706746084885057576</td>
-      <td><a href="manifests/manifest_230411_7706746084885057576.txt">36.37 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7706746084885057576.txt">36.37 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -125,7 +125,7 @@
     <tr>
       <td><code>2023-06-21T15:26:53Z</code></td>
       <td>1040973097284770411</td>
-      <td><a href="manifests/manifest_230411_1040973097284770411.txt">36.22 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1040973097284770411.txt">36.22 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -133,7 +133,7 @@
     <tr>
       <td><code>2023-04-26T15:25:09Z</code></td>
       <td>503269306359201928</td>
-      <td><a href="manifests/manifest_230411_503269306359201928.txt">35.77 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_503269306359201928.txt">35.77 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -141,7 +141,7 @@
     <tr>
       <td><code>2023-02-15T16:26:53Z</code></td>
       <td>2084947150827453084</td>
-      <td><a href="manifests/manifest_230411_2084947150827453084.txt">33.23 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2084947150827453084.txt">33.23 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -149,7 +149,7 @@
     <tr>
       <td><code>2022-11-30T16:31:17Z</code></td>
       <td>1591604753021484150</td>
-      <td><a href="manifests/manifest_230411_1591604753021484150.txt">35.93 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1591604753021484150.txt">35.93 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -157,7 +157,7 @@
     <tr>
       <td><code>2022-09-07T15:26:22Z</code></td>
       <td>2433324865707385268</td>
-      <td><a href="manifests/manifest_230411_2433324865707385268.txt">32.42 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2433324865707385268.txt">32.42 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -165,7 +165,7 @@
     <tr>
       <td><code>2022-07-26T13:03:53Z</code></td>
       <td>7280281005656793707</td>
-      <td><a href="manifests/manifest_230411_7280281005656793707.txt">32.09 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7280281005656793707.txt">32.09 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -173,7 +173,7 @@
     <tr>
       <td><code>2022-06-09T15:22:56Z</code></td>
       <td>8725083537193522917</td>
-      <td><a href="manifests/manifest_230411_8725083537193522917.txt">31.74 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8725083537193522917.txt">31.74 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -181,7 +181,7 @@
     <tr>
       <td><code>2022-04-29T17:44:10Z</code></td>
       <td>4634493262513910961</td>
-      <td><a href="manifests/manifest_230411_4634493262513910961.txt">31.70 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4634493262513910961.txt">31.70 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -189,7 +189,7 @@
     <tr>
       <td><code>2022-02-09T17:33:06Z</code></td>
       <td>1198361709927223847</td>
-      <td><a href="manifests/manifest_230411_1198361709927223847.txt">30.44 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1198361709927223847.txt">30.44 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -197,7 +197,7 @@
     <tr>
       <td><code>2021-12-15T16:48:38Z</code></td>
       <td>563653176338996292</td>
-      <td><a href="manifests/manifest_230411_563653176338996292.txt">30.50 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_563653176338996292.txt">30.50 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -205,7 +205,7 @@
     <tr>
       <td><code>2021-09-09T14:09:14Z</code></td>
       <td>8243603931064121923</td>
-      <td><a href="manifests/manifest_230411_8243603931064121923.txt">27.43 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8243603931064121923.txt">27.43 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -213,7 +213,7 @@
     <tr>
       <td><code>2021-09-09T00:45:12Z</code></td>
       <td>4538343592657854566</td>
-      <td><a href="manifests/manifest_230411_4538343592657854566.txt">28.04 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4538343592657854566.txt">28.04 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -221,7 +221,7 @@
     <tr>
       <td><code>2021-07-06T17:47:10Z</code></td>
       <td>1659398175797234554</td>
-      <td><a href="manifests/manifest_230411_1659398175797234554.txt">27.07 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1659398175797234554.txt">27.07 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -229,7 +229,7 @@
     <tr>
       <td><code>2021-06-03T14:18:03Z</code></td>
       <td>896988770099174429</td>
-      <td><a href="manifests/manifest_230411_896988770099174429.txt">26.82 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_896988770099174429.txt">26.82 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -237,7 +237,7 @@
     <tr>
       <td><code>2021-05-25T18:48:22Z</code></td>
       <td>1516755954909330587</td>
-      <td><a href="manifests/manifest_230411_1516755954909330587.txt">26.85 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1516755954909330587.txt">26.85 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -245,7 +245,7 @@
     <tr>
       <td><code>2021-04-14T22:10:40Z</code></td>
       <td>1471695976410467945</td>
-      <td><a href="manifests/manifest_230411_1471695976410467945.txt">26.43 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1471695976410467945.txt">26.43 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -253,7 +253,7 @@
     <tr>
       <td><code>2021-03-19T16:27:54Z</code></td>
       <td>2360447165794825746</td>
-      <td><a href="manifests/manifest_230411_2360447165794825746.txt">26.14 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2360447165794825746.txt">26.14 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -261,7 +261,7 @@
     <tr>
       <td><code>2021-01-25T17:51:43Z</code></td>
       <td>5695018007407901588</td>
-      <td><a href="manifests/manifest_230411_5695018007407901588.txt">24.72 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5695018007407901588.txt">24.72 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -269,7 +269,7 @@
     <tr>
       <td><code>2020-11-20T00:33:15Z</code></td>
       <td>2281391866826940520</td>
-      <td><a href="manifests/manifest_230411_2281391866826940520.txt">28.21 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2281391866826940520.txt">28.21 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -277,7 +277,7 @@
     <tr>
       <td><code>2020-11-05T13:33:46Z</code></td>
       <td>4589169429267220816</td>
-      <td><a href="manifests/manifest_230411_4589169429267220816.txt">27.85 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4589169429267220816.txt">27.85 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -285,7 +285,7 @@
     <tr>
       <td><code>2020-08-26T02:57:01Z</code></td>
       <td>1198696432420157033</td>
-      <td><a href="manifests/manifest_230411_1198696432420157033.txt">40.52 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1198696432420157033.txt">40.52 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -293,7 +293,7 @@
     <tr>
       <td><code>2020-08-13T03:06:19Z</code></td>
       <td>4862052161935324630</td>
-      <td><a href="manifests/manifest_230411_4862052161935324630.txt">37.51 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4862052161935324630.txt">37.51 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -301,7 +301,7 @@
     <tr>
       <td><code>2020-06-13T23:18:01Z</code></td>
       <td>8322392782655512672</td>
-      <td><a href="manifests/manifest_230411_8322392782655512672.txt">40.61 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8322392782655512672.txt">40.61 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -309,7 +309,7 @@
     <tr>
       <td><code>2020-03-25T04:24:11Z</code></td>
       <td>940429389442729133</td>
-      <td><a href="manifests/manifest_230411_940429389442729133.txt">38.92 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_940429389442729133.txt">38.92 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -317,7 +317,7 @@
     <tr>
       <td><code>2020-03-06T14:42:09Z</code></td>
       <td>3078917755629993445</td>
-      <td><a href="manifests/manifest_230411_3078917755629993445.txt">38.71 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3078917755629993445.txt">38.71 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -325,7 +325,7 @@
     <tr>
       <td><code>2019-12-14T16:20:11Z</code></td>
       <td>5383208407459190147</td>
-      <td><a href="manifests/manifest_230411_5383208407459190147.txt">36.80 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5383208407459190147.txt">36.80 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -333,7 +333,7 @@
     <tr>
       <td><code>2019-12-13T14:48:41Z</code></td>
       <td>1746499861411165604</td>
-      <td><a href="manifests/manifest_230411_1746499861411165604.txt">36.68 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1746499861411165604.txt">36.68 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -341,7 +341,7 @@
     <tr>
       <td><code>2019-11-23T12:40:50Z</code></td>
       <td>5191423722994130705</td>
-      <td><a href="manifests/manifest_230411_5191423722994130705.txt">39.99 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5191423722994130705.txt">39.99 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -349,7 +349,7 @@
     <tr>
       <td><code>2019-11-06T14:33:15Z</code></td>
       <td>4211752956119480973</td>
-      <td><a href="manifests/manifest_230411_4211752956119480973.txt">33.82 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4211752956119480973.txt">33.82 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -357,7 +357,7 @@
     <tr>
       <td><code>2019-11-01T13:56:52Z</code></td>
       <td>5213493012981659231</td>
-      <td><a href="manifests/manifest_230411_5213493012981659231.txt">33.97 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5213493012981659231.txt">33.97 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -365,7 +365,7 @@
     <tr>
       <td><code>2019-09-09T21:57:52Z</code></td>
       <td>6484357939617346090</td>
-      <td><a href="manifests/manifest_230411_6484357939617346090.txt">32.79 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6484357939617346090.txt">32.79 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -373,7 +373,7 @@
     <tr>
       <td><code>2019-08-30T12:44:29Z</code></td>
       <td>6955217559566015186</td>
-      <td><a href="manifests/manifest_230411_6955217559566015186.txt">35.00 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6955217559566015186.txt">35.00 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -381,7 +381,7 @@
     <tr>
       <td><code>2019-08-30T02:35:36Z</code></td>
       <td>8839989774604564585</td>
-      <td><a href="manifests/manifest_230411_8839989774604564585.txt">34.93 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8839989774604564585.txt">34.93 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -389,7 +389,7 @@
     <tr>
       <td><code>2019-05-23T12:53:33Z</code></td>
       <td>3318532863308652389</td>
-      <td><a href="manifests/manifest_230411_3318532863308652389.txt">31.35 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3318532863308652389.txt">31.35 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -397,7 +397,7 @@
     <tr>
       <td><code>2019-04-05T14:18:53Z</code></td>
       <td>192898029640470386</td>
-      <td><a href="manifests/manifest_230411_192898029640470386.txt">30.14 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_192898029640470386.txt">30.14 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -405,7 +405,7 @@
     <tr>
       <td><code>2019-03-18T14:06:18Z</code></td>
       <td>4942488930993990244</td>
-      <td><a href="manifests/manifest_230411_4942488930993990244.txt">29.21 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4942488930993990244.txt">29.21 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -413,7 +413,7 @@
     <tr>
       <td><code>2019-03-08T14:25:51Z</code></td>
       <td>4404971551504983924</td>
-      <td><a href="manifests/manifest_230411_4404971551504983924.txt">30.75 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4404971551504983924.txt">30.75 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -421,7 +421,7 @@
     <tr>
       <td><code>2019-03-08T03:30:15Z</code></td>
       <td>1904743723246597237</td>
-      <td><a href="manifests/manifest_230411_1904743723246597237.txt">31.31 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1904743723246597237.txt">31.31 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -429,7 +429,7 @@
     <tr>
       <td><code>2018-12-19T00:35:04Z</code></td>
       <td>174676543101364914</td>
-      <td><a href="manifests/manifest_230411_174676543101364914.txt">32.01 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_174676543101364914.txt">32.01 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -437,7 +437,7 @@
     <tr>
       <td><code>2018-11-30T00:21:43Z</code></td>
       <td>8040761247114336449</td>
-      <td><a href="manifests/manifest_230411_8040761247114336449.txt">28.26 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8040761247114336449.txt">28.26 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -445,7 +445,7 @@
     <tr>
       <td><code>2018-11-16T18:59:10Z</code></td>
       <td>3725569727599851360</td>
-      <td><a href="manifests/manifest_230411_3725569727599851360.txt">28.23 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3725569727599851360.txt">28.23 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -453,7 +453,7 @@
     <tr>
       <td><code>2018-11-16T01:12:10Z</code></td>
       <td>8461211368258506784</td>
-      <td><a href="manifests/manifest_230411_8461211368258506784.txt">28.03 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8461211368258506784.txt">28.03 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -461,7 +461,7 @@
     <tr>
       <td><code>2018-11-08T22:38:43Z</code></td>
       <td>6046541448142309692</td>
-      <td><a href="manifests/manifest_230411_6046541448142309692.txt">28.28 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6046541448142309692.txt">28.28 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -469,7 +469,7 @@
     <tr>
       <td><code>2018-10-12T15:32:11Z</code></td>
       <td>8049567794324118250</td>
-      <td><a href="manifests/manifest_230411_8049567794324118250.txt">24.68 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8049567794324118250.txt">24.68 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -477,7 +477,7 @@
     <tr>
       <td><code>2018-09-29T13:20:31Z</code></td>
       <td>1234607834806579897</td>
-      <td><a href="manifests/manifest_230411_1234607834806579897.txt">23.57 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1234607834806579897.txt">23.57 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -485,7 +485,7 @@
     <tr>
       <td><code>2018-08-03T00:35:58Z</code></td>
       <td>677450530474051174</td>
-      <td><a href="manifests/manifest_230411_677450530474051174.txt">23.31 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_677450530474051174.txt">23.31 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -493,7 +493,7 @@
     <tr>
       <td><code>2018-06-15T07:26:53Z</code></td>
       <td>8058901711639962245</td>
-      <td><a href="manifests/manifest_230411_8058901711639962245.txt">23.21 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8058901711639962245.txt">23.21 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -501,7 +501,7 @@
     <tr>
       <td><code>2018-05-18T02:36:51Z</code></td>
       <td>566447983471491143</td>
-      <td><a href="manifests/manifest_230411_566447983471491143.txt">23.27 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_566447983471491143.txt">23.27 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -509,7 +509,7 @@
     <tr>
       <td><code>2018-04-20T15:48:09Z</code></td>
       <td>8448828347811631025</td>
-      <td><a href="manifests/manifest_230411_8448828347811631025.txt">22.66 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8448828347811631025.txt">22.66 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -517,7 +517,7 @@
     <tr>
       <td><code>2018-03-16T14:05:50Z</code></td>
       <td>5922375304465722812</td>
-      <td><a href="manifests/manifest_230411_5922375304465722812.txt">22.51 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5922375304465722812.txt">22.51 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -525,7 +525,7 @@
     <tr>
       <td><code>2018-03-08T00:02:58Z</code></td>
       <td>6640882772717519747</td>
-      <td><a href="manifests/manifest_230411_6640882772717519747.txt">22.22 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6640882772717519747.txt">22.22 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -533,7 +533,7 @@
     <tr>
       <td><code>2018-02-23T14:19:09Z</code></td>
       <td>8004325165498360760</td>
-      <td><a href="manifests/manifest_230411_8004325165498360760.txt">25.80 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8004325165498360760.txt">25.80 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -541,7 +541,7 @@
     <tr>
       <td><code>2018-01-29T15:55:02Z</code></td>
       <td>8621631773919294851</td>
-      <td><a href="manifests/manifest_230411_8621631773919294851.txt">21.94 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8621631773919294851.txt">21.94 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -549,7 +549,7 @@
     <tr>
       <td><code>2018-01-05T15:11:15Z</code></td>
       <td>4946799727072561536</td>
-      <td><a href="manifests/manifest_230411_4946799727072561536.txt">21.80 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4946799727072561536.txt">21.80 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -557,7 +557,7 @@
     <tr>
       <td><code>2017-12-12T20:35:06Z</code></td>
       <td>5301169201249491747</td>
-      <td><a href="manifests/manifest_230411_5301169201249491747.txt">21.45 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5301169201249491747.txt">21.45 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -565,7 +565,7 @@
     <tr>
       <td><code>2017-12-08T23:50:30Z</code></td>
       <td>5914709226935570547</td>
-      <td><a href="manifests/manifest_230411_5914709226935570547.txt">21.94 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5914709226935570547.txt">21.94 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -573,7 +573,7 @@
     <tr>
       <td><code>2017-11-17T04:44:39Z</code></td>
       <td>5869273198520287595</td>
-      <td><a href="manifests/manifest_230411_5869273198520287595.txt">21.23 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5869273198520287595.txt">21.23 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -581,7 +581,7 @@
     <tr>
       <td><code>2017-10-12T23:45:41Z</code></td>
       <td>4661126446448856114</td>
-      <td><a href="manifests/manifest_230411_4661126446448856114.txt">22.22 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4661126446448856114.txt">22.22 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -589,7 +589,7 @@
     <tr>
       <td><code>2017-07-27T00:35:31Z</code></td>
       <td>1835327182756411758</td>
-      <td><a href="manifests/manifest_230411_1835327182756411758.txt">18.95 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1835327182756411758.txt">18.95 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -597,7 +597,7 @@
     <tr>
       <td><code>2017-06-29T14:39:04Z</code></td>
       <td>2970877824413815022</td>
-      <td><a href="manifests/manifest_230411_2970877824413815022.txt">18.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2970877824413815022.txt">18.73 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -605,7 +605,7 @@
     <tr>
       <td><code>2017-06-29T08:57:17Z</code></td>
       <td>9187782625344917768</td>
-      <td><a href="manifests/manifest_230411_9187782625344917768.txt">18.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_9187782625344917768.txt">18.73 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -613,7 +613,7 @@
     <tr>
       <td><code>2017-05-08T15:52:24Z</code></td>
       <td>3099723078202393524</td>
-      <td><a href="manifests/manifest_230411_3099723078202393524.txt">21.39 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3099723078202393524.txt">21.39 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -621,7 +621,7 @@
     <tr>
       <td><code>2017-03-26T10:38:34Z</code></td>
       <td>4574874014936523212</td>
-      <td><a href="manifests/manifest_230411_4574874014936523212.txt">21.29 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4574874014936523212.txt">21.29 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -629,7 +629,7 @@
     <tr>
       <td><code>2017-03-25T13:41:48Z</code></td>
       <td>8705016425420648723</td>
-      <td><a href="manifests/manifest_230411_8705016425420648723.txt">21.83 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8705016425420648723.txt">21.83 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -637,7 +637,7 @@
     <tr>
       <td><code>2017-03-07T00:24:59Z</code></td>
       <td>6263571497645662720</td>
-      <td><a href="manifests/manifest_230411_6263571497645662720.txt">21.21 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6263571497645662720.txt">21.21 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -645,7 +645,7 @@
     <tr>
       <td><code>2017-03-03T23:11:37Z</code></td>
       <td>2663512682334598162</td>
-      <td><a href="manifests/manifest_230411_2663512682334598162.txt">22.47 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2663512682334598162.txt">22.47 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -653,7 +653,7 @@
     <tr>
       <td><code>2017-03-03T14:04:08Z</code></td>
       <td>4864838558963648894</td>
-      <td><a href="manifests/manifest_230411_4864838558963648894.txt">22.47 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4864838558963648894.txt">22.47 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -661,7 +661,7 @@
     <tr>
       <td><code>2016-12-22T16:07:20Z</code></td>
       <td>4666421798085404101</td>
-      <td><a href="manifests/manifest_230411_4666421798085404101.txt">22.47 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4666421798085404101.txt">22.47 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -669,7 +669,7 @@
     <tr>
       <td><code>2016-12-17T00:17:57Z</code></td>
       <td>8998041413872250076</td>
-      <td><a href="manifests/manifest_230411_8998041413872250076.txt">19.92 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8998041413872250076.txt">19.92 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -677,7 +677,7 @@
     <tr>
       <td><code>2016-11-12T05:34:46Z</code></td>
       <td>6784000424578492584</td>
-      <td><a href="manifests/manifest_230411_6784000424578492584.txt">20.52 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6784000424578492584.txt">20.52 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -685,7 +685,7 @@
     <tr>
       <td><code>2016-09-30T22:21:05Z</code></td>
       <td>7585839495921050946</td>
-      <td><a href="manifests/manifest_230411_7585839495921050946.txt">17.45 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7585839495921050946.txt">17.45 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -693,7 +693,7 @@
     <tr>
       <td><code>2016-08-26T19:09:25Z</code></td>
       <td>2086935969100698619</td>
-      <td><a href="manifests/manifest_230411_2086935969100698619.txt">16.54 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2086935969100698619.txt">16.54 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -701,7 +701,7 @@
     <tr>
       <td><code>2016-08-19T23:36:41Z</code></td>
       <td>3584168904277131181</td>
-      <td><a href="manifests/manifest_230411_3584168904277131181.txt">16.38 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3584168904277131181.txt">16.38 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -709,7 +709,7 @@
     <tr>
       <td><code>2016-07-08T23:15:14Z</code></td>
       <td>8065552974390268707</td>
-      <td><a href="manifests/manifest_230411_8065552974390268707.txt">16.44 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8065552974390268707.txt">16.44 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -717,7 +717,7 @@
     <tr>
       <td><code>2016-04-01T14:57:19Z</code></td>
       <td>2087739745223261142</td>
-      <td><a href="manifests/manifest_230411_2087739745223261142.txt">17.31 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2087739745223261142.txt">17.31 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -725,7 +725,7 @@
     <tr>
       <td><code>2016-03-04T22:14:39Z</code></td>
       <td>1331043799698924734</td>
-      <td><a href="manifests/manifest_230411_1331043799698924734.txt">17.30 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1331043799698924734.txt">17.30 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -733,7 +733,7 @@
     <tr>
       <td><code>2015-12-10T14:42:30Z</code></td>
       <td>5378301586494814297</td>
-      <td><a href="manifests/manifest_230411_5378301586494814297.txt">14.77 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5378301586494814297.txt">14.77 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -741,7 +741,7 @@
     <tr>
       <td><code>2015-12-09T13:18:44Z</code></td>
       <td>4603106986143048670</td>
-      <td><a href="manifests/manifest_230411_4603106986143048670.txt">11.54 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4603106986143048670.txt">11.54 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -749,7 +749,7 @@
     <tr>
       <td><code>2015-12-07T15:05:29Z</code></td>
       <td>5567085556474789237</td>
-      <td><a href="manifests/manifest_230411_5567085556474789237.txt">11.54 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5567085556474789237.txt">11.54 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -757,7 +757,7 @@
     <tr>
       <td><code>2015-10-22T02:58:34Z</code></td>
       <td>2275730668734249647</td>
-      <td><a href="manifests/manifest_230411_2275730668734249647.txt">10.58 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2275730668734249647.txt">10.58 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -765,7 +765,7 @@
     <tr>
       <td><code>2015-10-21T02:18:16Z</code></td>
       <td>7055925076570413672</td>
-      <td><a href="manifests/manifest_230411_7055925076570413672.txt">10.51 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7055925076570413672.txt">10.51 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -773,7 +773,7 @@
     <tr>
       <td><code>2015-05-15T05:39:50Z</code></td>
       <td>232461576962714068</td>
-      <td><a href="manifests/manifest_230411_232461576962714068.txt">9.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_232461576962714068.txt">9.73 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -781,7 +781,7 @@
     <tr>
       <td><code>2015-03-21T14:38:17Z</code></td>
       <td>567734397704178704</td>
-      <td><a href="manifests/manifest_230411_567734397704178704.txt">9.24 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_567734397704178704.txt">9.24 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -789,7 +789,7 @@
     <tr>
       <td><code>2015-02-13T21:54:21Z</code></td>
       <td>5952644847955190118</td>
-      <td><a href="manifests/manifest_230411_5952644847955190118.txt">8.96 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5952644847955190118.txt">8.96 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -797,7 +797,7 @@
     <tr>
       <td><code>2014-11-27T22:44:26Z</code></td>
       <td>7377933404197762308</td>
-      <td><a href="manifests/manifest_230411_7377933404197762308.txt">8.26 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7377933404197762308.txt">8.26 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -805,7 +805,7 @@
     <tr>
       <td><code>2014-10-30T04:01:34Z</code></td>
       <td>6368936033089773713</td>
-      <td><a href="manifests/manifest_230411_6368936033089773713.txt">7.93 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6368936033089773713.txt">7.93 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -813,7 +813,7 @@
     <tr>
       <td><code>2014-10-29T02:48:52Z</code></td>
       <td>1212629036031221707</td>
-      <td><a href="manifests/manifest_230411_1212629036031221707.txt">8.16 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1212629036031221707.txt">8.16 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -821,7 +821,7 @@
     <tr>
       <td><code>2014-10-28T05:43:46Z</code></td>
       <td>1048315274024428186</td>
-      <td><a href="manifests/manifest_230411_1048315274024428186.txt">8.16 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1048315274024428186.txt">8.16 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -829,7 +829,7 @@
     <tr>
       <td><code>2014-10-24T14:45:50Z</code></td>
       <td>6636116079410913663</td>
-      <td><a href="manifests/manifest_230411_6636116079410913663.txt">7.81 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6636116079410913663.txt">7.81 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -837,7 +837,7 @@
     <tr>
       <td><code>2014-09-24T22:30:37Z</code></td>
       <td>4885795964507366541</td>
-      <td><a href="manifests/manifest_230411_4885795964507366541.txt">6.72 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4885795964507366541.txt">6.72 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -845,7 +845,7 @@
     <tr>
       <td><code>2014-09-23T21:47:50Z</code></td>
       <td>7887393592947262939</td>
-      <td><a href="manifests/manifest_230411_7887393592947262939.txt">6.72 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7887393592947262939.txt">6.72 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -853,7 +853,7 @@
     <tr>
       <td><code>2014-08-28T19:49:33Z</code></td>
       <td>8779732662024957928</td>
-      <td><a href="manifests/manifest_230411_8779732662024957928.txt">13.32 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8779732662024957928.txt">13.32 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -861,7 +861,7 @@
     <tr>
       <td><code>2014-07-22T02:23:23Z</code></td>
       <td>7091405412400346572</td>
-      <td><a href="manifests/manifest_230411_7091405412400346572.txt">6.37 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7091405412400346572.txt">6.37 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -869,7 +869,7 @@
     <tr>
       <td><code>2014-05-23T21:22:32Z</code></td>
       <td>7211838851606425341</td>
-      <td><a href="manifests/manifest_230411_7211838851606425341.txt">6.01 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7211838851606425341.txt">6.01 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -877,7 +877,7 @@
     <tr>
       <td><code>2014-04-11T13:09:40Z</code></td>
       <td>5876704438298513797</td>
-      <td><a href="manifests/manifest_230411_5876704438298513797.txt">5.91 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5876704438298513797.txt">5.91 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -885,7 +885,7 @@
     <tr>
       <td><code>2014-03-06T06:30:37Z</code></td>
       <td>3406168191948447048</td>
-      <td><a href="manifests/manifest_230411_3406168191948447048.txt">5.59 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3406168191948447048.txt">5.59 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -893,7 +893,7 @@
     <tr>
       <td><code>2014-02-21T01:41:31Z</code></td>
       <td>7515523599342296232</td>
-      <td><a href="manifests/manifest_230411_7515523599342296232.txt">4.55 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7515523599342296232.txt">4.55 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -901,7 +901,7 @@
     <tr>
       <td><code>2014-02-08T00:57:36Z</code></td>
       <td>4190426140757030330</td>
-      <td><a href="manifests/manifest_230411_4190426140757030330.txt">4.54 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4190426140757030330.txt">4.54 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -909,7 +909,7 @@
     <tr>
       <td><code>2013-12-22T15:14:08Z</code></td>
       <td>585340885135755161</td>
-      <td><a href="manifests/manifest_230411_585340885135755161.txt">4.53 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_585340885135755161.txt">4.53 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -917,7 +917,7 @@
     <tr>
       <td><code>2013-11-30T04:19:49Z</code></td>
       <td>2135033526713381905</td>
-      <td><a href="manifests/manifest_230411_2135033526713381905.txt">4.42 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_2135033526713381905.txt">4.42 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -925,7 +925,7 @@
     <tr>
       <td><code>2013-11-15T23:25:28Z</code></td>
       <td>4839307268506097307</td>
-      <td><a href="manifests/manifest_230411_4839307268506097307.txt">4.03 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4839307268506097307.txt">4.03 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -933,7 +933,7 @@
     <tr>
       <td><code>2013-10-11T23:07:52Z</code></td>
       <td>1764044531028780660</td>
-      <td><a href="manifests/manifest_230411_1764044531028780660.txt">4.17 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1764044531028780660.txt">4.17 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -941,7 +941,7 @@
     <tr>
       <td><code>2013-09-25T14:39:24Z</code></td>
       <td>1734697414845714540</td>
-      <td><a href="manifests/manifest_230411_1734697414845714540.txt">2.97 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1734697414845714540.txt">2.97 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -949,7 +949,7 @@
     <tr>
       <td><code>2013-08-14T18:17:36Z</code></td>
       <td>1806108333186250272</td>
-      <td><a href="manifests/manifest_230411_1806108333186250272.txt">2.97 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1806108333186250272.txt">2.97 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -957,7 +957,7 @@
     <tr>
       <td><code>2013-07-16T17:37:00Z</code></td>
       <td>3366147248454027595</td>
-      <td><a href="manifests/manifest_230411_3366147248454027595.txt">2.90 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3366147248454027595.txt">2.90 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -965,7 +965,7 @@
     <tr>
       <td><code>2013-07-05T20:27:14Z</code></td>
       <td>767517711548082020</td>
-      <td><a href="manifests/manifest_230411_767517711548082020.txt">2.94 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_767517711548082020.txt">2.94 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -973,7 +973,7 @@
     <tr>
       <td><code>2013-06-08T16:36:30Z</code></td>
       <td>647709821457915915</td>
-      <td><a href="manifests/manifest_230411_647709821457915915.txt">2.44 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_647709821457915915.txt">2.44 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -981,7 +981,7 @@
     <tr>
       <td><code>2013-05-23T21:53:36Z</code></td>
       <td>5108594067645371108</td>
-      <td><a href="manifests/manifest_230411_5108594067645371108.txt">2.43 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5108594067645371108.txt">2.43 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -989,7 +989,7 @@
     <tr>
       <td><code>2013-05-17T20:42:08Z</code></td>
       <td>7689210280991293768</td>
-      <td><a href="manifests/manifest_230411_7689210280991293768.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7689210280991293768.txt">1.73 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -997,7 +997,7 @@
     <tr>
       <td><code>2013-05-15T20:01:35Z</code></td>
       <td>367921302756169619</td>
-      <td><a href="manifests/manifest_230411_367921302756169619.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_367921302756169619.txt">1.73 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -1005,7 +1005,7 @@
     <tr>
       <td><code>2013-05-14T15:33:26Z</code></td>
       <td>5140912318581454574</td>
-      <td><a href="manifests/manifest_230411_5140912318581454574.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5140912318581454574.txt">1.73 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -1013,7 +1013,7 @@
     <tr>
       <td><code>2013-05-13T20:37:57Z</code></td>
       <td>1873918047633104541</td>
-      <td><a href="manifests/manifest_230411_1873918047633104541.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1873918047633104541.txt">1.73 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -1021,7 +1021,7 @@
     <tr>
       <td><code>2013-05-10T19:52:43Z</code></td>
       <td>609302931784914878</td>
-      <td><a href="manifests/manifest_230411_609302931784914878.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_609302931784914878.txt">1.73 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -1029,7 +1029,7 @@
     <tr>
       <td><code>2013-05-09T20:06:49Z</code></td>
       <td>1333808825789667682</td>
-      <td><a href="manifests/manifest_230411_1333808825789667682.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1333808825789667682.txt">1.73 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -1037,7 +1037,7 @@
     <tr>
       <td><code>2013-05-09T17:49:16Z</code></td>
       <td>6812997867589219032</td>
-      <td><a href="manifests/manifest_230411_6812997867589219032.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6812997867589219032.txt">1.73 GiB</a></td>
       <td></td>
       <td></td>
       <td></td>
@@ -1045,162 +1045,162 @@
     <tr>
       <td><code>2013-05-08T16:52:18Z</code></td>
       <td>1214562332840994196</td>
-      <td><a href="manifests/manifest_230411_1214562332840994196.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1214562332840994196.txt">1.73 GiB</a></td>
       <td><a href="ipfs/1214562332840994196.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/1214562332840994196%20to%204151868779723562813.txt">2.92 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/1214562332840994196%20to%204151868779723562813.txt">2.92 MiB</a></td>
       <td></td>
     </tr>
     <tr>
       <td><code>2013-05-06T17:28:17Z</code></td>
       <td>4151868779723562813</td>
-      <td><a href="manifests/manifest_230411_4151868779723562813.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_4151868779723562813.txt">1.73 GiB</a></td>
       <td><a href="ipfs/4151868779723562813.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/4151868779723562813%20to%20588705282697359018.txt">2.46 MiB</a></td>
-      <td>↑ <a href="deltas/4151868779723562813%20to%201214562332840994196.txt">2.91 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/4151868779723562813%20to%20588705282697359018.txt">2.46 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/4151868779723562813%20to%201214562332840994196.txt">2.91 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-05-04T06:56:10Z</code></td>
       <td>588705282697359018</td>
-      <td><a href="manifests/manifest_230411_588705282697359018.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_588705282697359018.txt">1.73 GiB</a></td>
       <td><a href="ipfs/588705282697359018.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/588705282697359018%20to%203767535784967645478.txt">2.45 MiB</a></td>
-      <td>↑ <a href="deltas/588705282697359018%20to%204151868779723562813.txt">2.46 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/588705282697359018%20to%203767535784967645478.txt">2.45 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/588705282697359018%20to%204151868779723562813.txt">2.46 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-05-04T02:25:06Z</code></td>
       <td>3767535784967645478</td>
-      <td><a href="manifests/manifest_230411_3767535784967645478.txt">1.73 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3767535784967645478.txt">1.73 GiB</a></td>
       <td><a href="ipfs/3767535784967645478.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/3767535784967645478%20to%206399786153404128119.txt">113.58 MiB</a></td>
-      <td>↑ <a href="deltas/3767535784967645478%20to%20588705282697359018.txt">2.46 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/3767535784967645478%20to%206399786153404128119.txt">113.58 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/3767535784967645478%20to%20588705282697359018.txt">2.46 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-26T22:50:59Z</code></td>
       <td>6399786153404128119</td>
-      <td><a href="manifests/manifest_230411_6399786153404128119.txt">1.81 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6399786153404128119.txt">1.81 GiB</a></td>
       <td><a href="ipfs/6399786153404128119.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/6399786153404128119%20to%205877621706072454395.txt">175.76 MiB</a></td>
-      <td>↑ <a href="deltas/6399786153404128119%20to%203767535784967645478.txt">100.39 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/6399786153404128119%20to%205877621706072454395.txt">175.76 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/6399786153404128119%20to%203767535784967645478.txt">100.39 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-25T18:24:57Z</code></td>
       <td>5877621706072454395</td>
-      <td><a href="manifests/manifest_230411_5877621706072454395.txt">1.46 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5877621706072454395.txt">1.46 GiB</a></td>
       <td><a href="ipfs/5877621706072454395.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/5877621706072454395%20to%206629234302933135021.txt">2.45 MiB</a></td>
-      <td>↑ <a href="deltas/5877621706072454395%20to%206399786153404128119.txt">396.54 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/5877621706072454395%20to%206629234302933135021.txt">2.45 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/5877621706072454395%20to%206399786153404128119.txt">396.54 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-24T17:26:42Z</code></td>
       <td>6629234302933135021</td>
-      <td><a href="manifests/manifest_230411_6629234302933135021.txt">1.46 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6629234302933135021.txt">1.46 GiB</a></td>
       <td><a href="ipfs/6629234302933135021.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/6629234302933135021%20to%201241849711849802633.txt">2.46 MiB</a></td>
-      <td>↑ <a href="deltas/6629234302933135021%20to%205877621706072454395.txt">2.45 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/6629234302933135021%20to%201241849711849802633.txt">2.46 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/6629234302933135021%20to%205877621706072454395.txt">2.45 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-24T16:09:01Z</code></td>
       <td>1241849711849802633</td>
-      <td><a href="manifests/manifest_230411_1241849711849802633.txt">1.46 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1241849711849802633.txt">1.46 GiB</a></td>
       <td><a href="ipfs/1241849711849802633.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/1241849711849802633%20to%201305013661316056540.txt">405.32 MiB</a></td>
-      <td>↑ <a href="deltas/1241849711849802633%20to%206629234302933135021.txt">2.45 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/1241849711849802633%20to%201305013661316056540.txt">405.32 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/1241849711849802633%20to%206629234302933135021.txt">2.45 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-19T22:16:10Z</code></td>
       <td>1305013661316056540</td>
-      <td><a href="manifests/manifest_230411_1305013661316056540.txt">1.92 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1305013661316056540.txt">1.92 GiB</a></td>
       <td><a href="ipfs/1305013661316056540.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/1305013661316056540%20to%207565171876923122883.txt">2.37 MiB</a></td>
-      <td>↑ <a href="deltas/1305013661316056540%20to%201241849711849802633.txt">160.35 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/1305013661316056540%20to%207565171876923122883.txt">2.37 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/1305013661316056540%20to%201241849711849802633.txt">160.35 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-19T21:20:42Z</code></td>
       <td>7565171876923122883</td>
-      <td><a href="manifests/manifest_230411_7565171876923122883.txt">1.92 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_7565171876923122883.txt">1.92 GiB</a></td>
       <td><a href="ipfs/7565171876923122883.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/7565171876923122883%20to%208278491043607750104.txt">105.36 MiB</a></td>
-      <td>↑ <a href="deltas/7565171876923122883%20to%201305013661316056540.txt">2.39 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/7565171876923122883%20to%208278491043607750104.txt">105.36 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/7565171876923122883%20to%201305013661316056540.txt">2.39 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-15T20:19:38Z</code></td>
       <td>8278491043607750104</td>
-      <td><a href="manifests/manifest_230411_8278491043607750104.txt">1.66 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8278491043607750104.txt">1.66 GiB</a></td>
       <td><a href="ipfs/8278491043607750104.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/8278491043607750104%20to%206961091191944066345.txt">91.87 MiB</a></td>
-      <td>↑ <a href="deltas/8278491043607750104%20to%207565171876923122883.txt">196.84 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/8278491043607750104%20to%206961091191944066345.txt">91.87 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/8278491043607750104%20to%207565171876923122883.txt">196.84 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-12T21:18:25Z</code></td>
       <td>6961091191944066345</td>
-      <td><a href="manifests/manifest_230411_6961091191944066345.txt">1.85 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6961091191944066345.txt">1.85 GiB</a></td>
       <td><a href="ipfs/6961091191944066345.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/6961091191944066345%20to%208357063435845098593.txt">56.40 MiB</a></td>
-      <td>↑ <a href="deltas/6961091191944066345%20to%208278491043607750104.txt">39.90 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/6961091191944066345%20to%208357063435845098593.txt">56.40 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/6961091191944066345%20to%208278491043607750104.txt">39.90 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-05T18:29:38Z</code></td>
       <td>8357063435845098593</td>
-      <td><a href="manifests/manifest_230411_8357063435845098593.txt">1.61 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8357063435845098593.txt">1.61 GiB</a></td>
       <td><a href="ipfs/8357063435845098593.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/8357063435845098593%20to%203065430017475545834.txt">81.55 MiB</a></td>
-      <td>↑ <a href="deltas/8357063435845098593%20to%206961091191944066345.txt">239.44 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/8357063435845098593%20to%203065430017475545834.txt">81.55 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/8357063435845098593%20to%206961091191944066345.txt">239.44 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-04T17:47:39Z</code></td>
       <td>3065430017475545834</td>
-      <td><a href="manifests/manifest_230411_3065430017475545834.txt">1.46 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_3065430017475545834.txt">1.46 GiB</a></td>
       <td><a href="ipfs/3065430017475545834.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/3065430017475545834%20to%206180757407260335433.txt">77.02 MiB</a></td>
-      <td>↑ <a href="deltas/3065430017475545834%20to%208357063435845098593.txt">104.92 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/3065430017475545834%20to%206180757407260335433.txt">77.02 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/3065430017475545834%20to%208357063435845098593.txt">104.92 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-03T21:30:46Z</code></td>
       <td>6180757407260335433</td>
-      <td><a href="manifests/manifest_230411_6180757407260335433.txt">1.51 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_6180757407260335433.txt">1.51 GiB</a></td>
       <td><a href="ipfs/6180757407260335433.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/6180757407260335433%20to%201412521350878833822.txt">18.08 MiB</a></td>
-      <td>↑ <a href="deltas/6180757407260335433%20to%203065430017475545834.txt">78.25 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/6180757407260335433%20to%201412521350878833822.txt">18.08 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/6180757407260335433%20to%203065430017475545834.txt">78.25 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-04-01T21:20:41Z</code></td>
       <td>1412521350878833822</td>
-      <td><a href="manifests/manifest_230411_1412521350878833822.txt">1.44 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1412521350878833822.txt">1.44 GiB</a></td>
       <td><a href="ipfs/1412521350878833822.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/1412521350878833822%20to%205572824118589588358.txt">56.46 MiB</a></td>
-      <td>↑ <a href="deltas/1412521350878833822%20to%206180757407260335433.txt">37.74 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/1412521350878833822%20to%205572824118589588358.txt">56.46 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/1412521350878833822%20to%206180757407260335433.txt">37.74 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-03-28T21:50:48Z</code></td>
       <td>5572824118589588358</td>
-      <td><a href="manifests/manifest_230411_5572824118589588358.txt">1.55 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_5572824118589588358.txt">1.55 GiB</a></td>
       <td><a href="ipfs/5572824118589588358.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/5572824118589588358%20to%208927238311553521114.txt">28.28 MiB</a></td>
-      <td>↑ <a href="deltas/5572824118589588358%20to%201412521350878833822.txt">10.95 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/5572824118589588358%20to%208927238311553521114.txt">28.28 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/5572824118589588358%20to%201412521350878833822.txt">10.95 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-03-28T11:31:38Z</code></td>
       <td>8927238311553521114</td>
-      <td><a href="manifests/manifest_230411_8927238311553521114.txt">1.46 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_8927238311553521114.txt">1.46 GiB</a></td>
       <td><a href="ipfs/8927238311553521114.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/8927238311553521114%20to%201958670258248515033.txt">23.74 MiB</a></td>
-      <td>↑ <a href="deltas/8927238311553521114%20to%205572824118589588358.txt">54.22 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/8927238311553521114%20to%201958670258248515033.txt">23.74 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/8927238311553521114%20to%205572824118589588358.txt">54.22 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-03-27T14:29:07Z</code></td>
       <td>1958670258248515033</td>
-      <td><a href="manifests/manifest_230411_1958670258248515033.txt">1.50 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_1958670258248515033.txt">1.50 GiB</a></td>
       <td><a href="ipfs/1958670258248515033.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/1958670258248515033%20to%209176710083987114410.txt">6.45 MiB</a></td>
-      <td>↑ <a href="deltas/1958670258248515033%20to%208927238311553521114.txt">16.62 MiB</a></td>
+      <td style="text-align: right;">↓ <a href="deltas/1958670258248515033%20to%209176710083987114410.txt">6.45 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/1958670258248515033%20to%208927238311553521114.txt">16.62 MiB</a></td>
     </tr>
     <tr>
       <td><code>2013-03-25T20:54:36Z</code></td>
       <td>9176710083987114410</td>
-      <td><a href="manifests/manifest_230411_9176710083987114410.txt">1.47 GiB</a></td>
+      <td style="text-align: right;"><a href="manifests/manifest_230411_9176710083987114410.txt">1.47 GiB</a></td>
       <td><a href="ipfs/9176710083987114410.txt">IPFS CIDs</a></td>
       <td></td>
-      <td>↑ <a href="deltas/9176710083987114410%20to%201958670258248515033.txt">12.28 MiB</a></td>
+      <td style="text-align: right;">↑ <a href="deltas/9176710083987114410%20to%201958670258248515033.txt">12.28 MiB</a></td>
     </tr>
   </tbody>
 </table>

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -90,7 +90,9 @@ function writeTable() {
   for (const row of rows) {
     fh.write("    <tr>\n");
     for (const col of row) {
-      fh.write(`      <td>${col || ""}</td>\n`);
+      const attrs =
+        col && /(GiB|MiB)/.test(col) ? ' style="text-align: right;"' : "";
+      fh.write(`      <td${attrs}>${col || ""}</td>\n`);
     }
     fh.write("    </tr>\n");
   }


### PR DESCRIPTION
## Summary
- right-align table cells containing GiB and MiB values

## Testing
- `npm run update`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b03d999a848325bee34c8de9b07493