### PR TITLE
feat: switch between MiB and GiB automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
       <td>8391191747297658560</td>
       <td><a href="manifests/manifest_230411_8391191747297658560.txt">46.38 GiB</a></td>
       <td><a href="ipfs/8391191747297658560.txt">IPFS CIDs</a></td>
-      <td>↓ <a href="deltas/8391191747297658560%20to%206046892458385712496.txt">2584.29 MiB</a></td>
+      <td>↓ <a href="deltas/8391191747297658560%20to%206046892458385712496.txt">2.52 GiB</a></td>
       <td></td>
     </tr>
     <tr>
@@ -24,7 +24,7 @@
       <td><a href="manifests/manifest_230411_6046892458385712496.txt">45.95 GiB</a></td>
       <td><a href="ipfs/6046892458385712496.txt">IPFS CIDs</a></td>
       <td></td>
-      <td>↑ <a href="deltas/6046892458385712496%20to%208391191747297658560.txt">3002.47 MiB</a></td>
+      <td>↑ <a href="deltas/6046892458385712496%20to%208391191747297658560.txt">2.93 GiB</a></td>
     </tr>
     <tr>
       <td><code>2025-03-19T14:55:56Z</code></td>
@@ -1209,5 +1209,5 @@
 Total size:            3,144,971,165,693 bytes ≈ 2928.98 GiB
 - Content:             3,136,262,425,821 bytes ≈ 2920.87 GiB
   - Unique files only: 2,835,830,598,290 bytes ≈ 2641.07 GiB
-- Deltas:                  8,708,739,872 bytes ≈    8.11 GiB
+- Deltas:                  8,708,739,872 bytes ≈ 8.11 GiB
 ```

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -1,6 +1,13 @@
 const fs = require("fs");
 const path = require("path");
 
+function formatBytes(bytes) {
+  const useGiB = bytes >= 1024 ** 3;
+  const divisor = useGiB ? 1024 ** 3 : 1024 ** 2;
+  const unit = useGiB ? "GiB" : "MiB";
+  return `${(bytes / divisor).toFixed(2)} ${unit}`;
+}
+
 function getSize() {
   let contentBytes = 0;
   let uniqueContentBytes = 0;
@@ -41,16 +48,25 @@ function getSize() {
   const totalBytes = contentBytes + deltaBytes;
 
   return (
-    `Total size:            ${totalBytes.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")} bytes ≈ ${(totalBytes / 1024 ** 3).toFixed(2)} GiB\n` +
-    `- Content:             ${contentBytes.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")} bytes ≈ ${(contentBytes / 1024 ** 3).toFixed(2)} GiB\n` +
-    `  - Unique files only: ${uniqueContentBytes.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")} bytes ≈ ${(uniqueContentBytes / 1024 ** 3).toFixed(2)} GiB\n` +
+    `Total size:            ${totalBytes
+      .toString()
+      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")} bytes ≈ ${formatBytes(
+      totalBytes,
+    )}\n` +
+    `- Content:             ${contentBytes
+      .toString()
+      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")} bytes ≈ ${formatBytes(
+      contentBytes,
+    )}\n` +
+    `  - Unique files only: ${uniqueContentBytes
+      .toString()
+      .replace(/\B(?=(\d{3})+(?!\d))/g, ",")} bytes ≈ ${formatBytes(
+      uniqueContentBytes,
+    )}\n` +
     `- Deltas:              ${deltaBytes
       .toString()
       .replace(/\B(?=(\d{3})+(?!\d))/g, ",")
-      .padStart(
-        17,
-        " ",
-      )} bytes ≈ ${(deltaBytes / 1024 ** 3).toFixed(2).padStart(7, " ")} GiB\n`
+      .padStart(17, " ")} bytes ≈ ${formatBytes(deltaBytes)}\n`
   );
 }
 
@@ -127,10 +143,9 @@ for (const manifest of manifests) {
       path.join(__dirname, "..", `manifests/manifest_230411_${mid}.txt`),
     )
   ) {
-    content = `<a href="manifests/manifest_230411_${mid}.txt">${(
-      getManifestDiskSize(mid) /
-      1024 ** 3
-    ).toFixed(2)} GiB</a>`;
+    content = `<a href="manifests/manifest_230411_${mid}.txt">${formatBytes(
+      getManifestDiskSize(mid),
+    )}</a>`;
   }
   if (fs.existsSync(path.join(__dirname, "..", `ipfs/${mid}.txt`))) {
     cids = `<a href="ipfs/${mid}.txt">IPFS CIDs</a>`;
@@ -152,10 +167,7 @@ for (const manifest of manifests) {
       )
       .split("\n");
     const downLink = encodeURI(`deltas/${mid} to ${manifest.older.mid}.txt`);
-    downdelta = `↓ <a href="${downLink}">${(
-      Number(deltaSize) /
-      1024 ** 2
-    ).toFixed(2)} MiB</a>`;
+    downdelta = `↓ <a href="${downLink}">${formatBytes(Number(deltaSize))}</a>`;
   }
   if (
     manifest.newer &&
@@ -174,9 +186,7 @@ for (const manifest of manifests) {
       )
       .split("\n");
     const upLink = encodeURI(`deltas/${mid} to ${manifest.newer.mid}.txt`);
-    updelta = `↑ <a href="${upLink}">${(Number(deltaSize) / 1024 ** 2).toFixed(
-      2,
-    )} MiB</a>`;
+    updelta = `↑ <a href="${upLink}">${formatBytes(Number(deltaSize))}</a>`;
   }
   addRow(
     `<code>${manifest.date}</code>`,


### PR DESCRIPTION
## Summary
- add `formatBytes` helper to switch between MiB and GiB based on size
- update size reporting and README generation to use automatic units

## Testing
- `npx prettier --write scripts/update.js README.md`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b2642879f8832583d4e9c1c5e4660c